### PR TITLE
feat: add option to disable convertion to ascii

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Given a YAML file like this:
 countries:
   normalize: true
   lowercase: true
+  asciify: true
   options:
     - match: Frankreich
       value: France
@@ -61,8 +62,10 @@ countries:
   # throw a `datapatch.exc:LookupException`.
   required: true
   # Normalisation will remove many special characters, remove multiple spaces
-  # and perform some basic matching across alphabets (Путин -> Putin).
   normalize: false
+  # By default normalize perform transliteration across alphabets (Путин -> Putin)
+  # set asciify to false if you want to keep non-ascii alphabets as is
+  asciify: false
   options:
     - match: Francois
       value: France

--- a/datapatch/lookup.py
+++ b/datapatch/lookup.py
@@ -22,6 +22,7 @@ class Lookup(object):
         self.required = as_bool(config.get("required", False))
         self.normalize = as_bool(config.get("normalize", False))
         self.lowercase = as_bool(config.get("lowercase", False))
+        self.asciify = as_bool(config.get("asciify", True))
         self.options: Set[Option] = set()
         self.unmatched: Set[Optional[str]] = set()
         option_data: List[Any] = []

--- a/datapatch/option.py
+++ b/datapatch/option.py
@@ -19,6 +19,7 @@ class Option(object):
         self.lookup = lookup
         self.normalize = as_bool(config.pop("normalize", lookup.normalize))
         self.lowercase = as_bool(config.pop("lowercase", lookup.lowercase))
+        self.asciify = as_bool(config.pop("asciify", lookup.asciify))
         self.weight = int(config.pop("weight", 0))
         self.ref_count = 0
 
@@ -26,13 +27,13 @@ class Option(object):
         _matches = str_list(config.pop("match", []))
         self.none_matches = None in _matches
         for match in _matches:
-            match_norm = normalize_value(match, self.normalize, self.lowercase)
+            match_norm = normalize_value(match, self.normalize, self.lowercase, self.asciify)
             if match_norm is not None:
                 match_re = re.escape(match_norm)
                 self.clauses.add(f"^{match_re}$")
 
         for contain in str_list(config.pop("contains", [])):
-            contain_norm = normalize_value(contain, self.normalize, self.lowercase)
+            contain_norm = normalize_value(contain, self.normalize, self.lowercase, self.asciify)
             if contain_norm is not None:
                 contain_re = re.escape(contain_norm)
                 self.clauses.add(f".*{contain_re}.*")
@@ -49,7 +50,7 @@ class Option(object):
             raise DataPatchException("Cannot match: %r" % self)
 
     def matches(self, value: Optional[str]) -> bool:
-        norm = normalize_value(value, self.normalize, self.lowercase)
+        norm = normalize_value(value, self.normalize, self.lowercase, self.asciify)
         if norm is None:
             return self.none_matches
         if len(self.clauses) == 0:

--- a/datapatch/util.py
+++ b/datapatch/util.py
@@ -43,10 +43,10 @@ def split_options(options: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
 
 @lru_cache(maxsize=20000)
 def normalize_value(
-    value: Any, normalize_: bool = False, lowercase: bool = False
+    value: Any, normalize_: bool = False, lowercase: bool = False, asciify: bool = True
 ) -> Optional[str]:
     if normalize_:
-        return normalize(value, ascii=True, lowercase=lowercase)
+        return normalize(value, ascii=asciify, lowercase=lowercase)
 
     text = stringify(value)
     if text is None:

--- a/tests/fixtures/countries.yml
+++ b/tests/fixtures/countries.yml
@@ -66,3 +66,11 @@ result:
   options:
     - match: Korea
       type: Dictatorship
+
+nonlatin:
+  normalize: true
+  asciify: false
+  lowercase: true
+  options:
+    - match: Порошенко Петро Олексійович
+      value: порошенко петро олексіиович

--- a/tests/test_lookup.py
+++ b/tests/test_lookup.py
@@ -67,3 +67,8 @@ def test_result():
     assert result.match("Korea").type == "Dictatorship"
     assert "Dictatorship" in repr(result.match("Korea"))
     assert result.match("Banana") is None
+
+def test_nonlatin():
+    nonlatin = lookups.get("nonlatin")
+    assert nonlatin.get_value("Порошенко Петро Олексійович") == "порошенко петро олексіиович"
+    assert nonlatin.get_value("Порошенко-Петро-Олексійович!") == "порошенко петро олексіиович"


### PR DESCRIPTION
Sometimes it's useful to keep data in original language, so I added option which still allows you to normalize values, but without converting to ascii.